### PR TITLE
Fixed not requesting ads at non-GDPR countries

### DIFF
--- a/samples/Jc.AdMob.Avalonia.Sample.Android/Jc.AdMob.Avalonia.Sample.Android.csproj
+++ b/samples/Jc.AdMob.Avalonia.Sample.Android/Jc.AdMob.Avalonia.Sample.Android.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0-android</TargetFramework>
-        <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
         <ApplicationId>com.CompanyName.Jc.AdMob.Avalonia.Sample</ApplicationId>
         <ApplicationVersion>1</ApplicationVersion>

--- a/src/Jc.AdMob.Avalonia.iOS/AdConsentiOS.cs
+++ b/src/Jc.AdMob.Avalonia.iOS/AdConsentiOS.cs
@@ -22,13 +22,13 @@ internal sealed class AdConsentiOS : IAdConsent
     public bool IsInitialized => _isInitialized;
 
     public bool CanShowAds => _options.SkipConsent ||
-                              (ConsentInformation.SharedInstance?.ConsentStatus is ConsentStatus.Obtained
-                                  or ConsentStatus.NotRequired && CanShowAdsInternal());
+                              ConsentInformation.SharedInstance?.ConsentStatus is ConsentStatus.NotRequired ||
+                              (ConsentInformation.SharedInstance?.ConsentStatus is ConsentStatus.Obtained && CanShowAdsInternal());
 
     public bool CanShowPersonalizedAds => _attStatus == ATTrackingManagerAuthorizationStatus.Authorized &&
                                           (_options.SkipConsent ||
-                                           (ConsentInformation.SharedInstance?.ConsentStatus is ConsentStatus.Obtained
-                                               or ConsentStatus.NotRequired && CanShowPersonalizedAdsInternal()));
+                                          ConsentInformation.SharedInstance?.ConsentStatus is ConsentStatus.NotRequired ||
+                                          (ConsentInformation.SharedInstance?.ConsentStatus is ConsentStatus.Obtained && CanShowPersonalizedAdsInternal()));
 
     public AdConsentiOS(AdMobOptions options)
     {


### PR DESCRIPTION
If GDPR message created at AdMob console targets only GDPR countries, consent form is not required at non-GDPR countries. This causes LoadAndShowConsentFormIfRequired() method not to be called at those countries, but library code always checks consent presence, causing not requesting ads at this case.

Library code always checks consent presence through CanShowAds and CanShowPersonalizedAds boolean properties (i.e. at BannerAdAndroid.cs and BannerAdiOS.cs, CreateControl()), which in turn call CanShowAdsInternal() and CanShowPersonalizedAdsInternal() methods respectively. Those methods check consent presence, and return always false at non-GDPR countries at the case described above. This hooks RenderBanner() to OnConsentProvided event handler, which is never fired.

This PR proposes to solve this issue by altering evaluations of CanShowAds and CanShowPersonalizedAds properties at AdConsentAndroid.cs and AdConsentiOS.cs, by making them evaluate to true if ConsentStatus is NotRequired, without calling CanShowAdsInternal() and CanShowPersonalizedAdsInternal() methods.

In addition, at ShowConsent() in AdConsentAndroid.cs, LoadAndShowConsentFormIfRequired() method must be called without checking consent requirement, the method will show the form only if the consent is required, and will always fire OnConsentProvided event, which is necessary for ads to be requested at non-GDPR countries, since CanShowAds property is false at the first launch of app.

Tested on Android device, works fine at cases GDPR message targets "GDPR countries" and "Everywhere".

P.S. Increased Android project's SupportedOSPlatformVersion (minSdkVersion) to 23 to be compliant with com.google.android.gms.ads_base.