### PR TITLE
fix: implement banner automation peer

### DIFF
--- a/src/Jc.AdMob.Avalonia/AdMobAutomationPeer.cs
+++ b/src/Jc.AdMob.Avalonia/AdMobAutomationPeer.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+
+namespace Jc.AdMob.Avalonia;
+
+internal sealed class AdMobAutomationPeer(Control owner) : ControlAutomationPeer(owner)
+{
+    protected override IReadOnlyList<AutomationPeer> GetOrCreateChildrenCore()
+        => [];
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+        => AutomationControlType.Custom;
+}

--- a/src/Jc.AdMob.Avalonia/BannerAd.cs
+++ b/src/Jc.AdMob.Avalonia/BannerAd.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Platform;
 
@@ -29,7 +30,10 @@ public sealed class BannerAd : NativeControlHost
         return Implementation?.CreateControl(UnitId, this, parent, () => base.CreateNativeControlCore(parent))
                ?? base.CreateNativeControlCore(parent);
     }
-    
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+        => new AdMobAutomationPeer(this);
+
     internal void AdLoaded(object? sender, EventArgs e) => OnAdLoaded?.Invoke(sender, e);
     internal void AdFailedToLoad(object? sender, AdError e) => OnAdFailedToLoad?.Invoke(sender, e);
     internal void AdImpression(object? sender, EventArgs e) => OnAdImpression?.Invoke(sender, e);


### PR DESCRIPTION
Fixes #34 
Apps like Bitdefender must use accessibility permissions to traverse the control tree causing a not implemented exception.

This PR implements the `GetOrCreateChildrenCore()` method and attaches it to the `BannerAd` control.